### PR TITLE
Add delete all functionality

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -106,7 +106,7 @@ Examples:
 Shows a summary of attendance records including list of absentees.
 
 Format: `list attendance tn/TUTORIALNUMBER [tg/TUTORIALGROUPID]`
-*  Shows a list of absentees and summary of the attendance records of students corresponding to the tutorial group for the specified tutorial number.
+*  Shows a list of absentees and summary of the attendance records of all students or students corresponding to the specified tutorial group for the specified tutorial number.
 * `TUTORIALGROUPID` is optional.
 
 Examples:
@@ -212,13 +212,15 @@ Examples:
 
 ### Deleting a person : `delete all`
 
-Deletes all students from the specified course or tutorial group of course.
+Deletes all students from current address book or the specified tutorial group in the current address book.
 
-Format: `delete all tg/TUTORIALGROUPID`
+Format: `delete all [tg/TUTORIALGROUPID]`
 
-* Deletes the students from the specified tutorial group.
+* Deletes all students or the students from the specified tutorial group.
+* `TUTORIALGROUPID` is optional.
 
 Examples:
+* `delete all` deletes all students from the current address book.
 * `delete all coursetg/G02` deletes all students from tutorial group G02.
 
 ### Clearing all entries : `clear`
@@ -265,13 +267,13 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
-| Action     | Format, Examples                                                                                                     |
-|------------|----------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL id/STUDENT_ID [t/COURSECODE TUTORIALGROUPID]...` <br>                             |
-| **Clear**  | `clear`                                                                                                              |
-| **Delete** | `delete all coursetg/COURSECODE [TUTORIALGROUPID]` `delete INDEX` <br> e.g., `delete all coursetg/CS2103T` `delete 3` |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [id/STUDENT_ID] [t/COURSECODE TUTORIALGROUPID]...`<br>                      |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                           |
-| **List**   | `list attendance tn/TUTORIALNO [coursetg/TAG]` `list students`                                                       |                                                           |
-| **Help**   | `help`                                                                                                               |
-| **Filter**   | `filter [add/delete/clear] [coursetg/COURSECODE] [tg/TUTORIALGROUPID]`                                               |
+| Action     | Format, Examples                                                                                |
+|------------|-------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL id/STUDENT_ID [t/COURSECODE TUTORIALGROUPID]...` <br>        |
+| **Clear**  | `clear`                                                                                         |
+| **Delete** | `delete all [tg/TUTORIALGROUPID]` `delete INDEX` <br> e.g., `delete all tg/G10` `delete 3`      |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [id/STUDENT_ID] [t/COURSECODE TUTORIALGROUPID]...`<br> |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                      |
+| **List**   | `list attendance tn/TUTORIALNO [tg/TUTORIALGROUPID]` `list students`                            |                                                           |
+| **Help**   | `help`                                                                                          |
+| **Filter**   | `filter [add/delete/clear] [coursetg/COURSECODE] [tg/TUTORIALGROUPID]`                          |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,12 +105,14 @@ Examples:
 
 Shows a summary of attendance records including list of absentees.
 
-Format: `list attendance tn/TUTORIALNO [coursetg/TAG]`
-*  Shows a list of absentees and summary of the attendance records of students corresponding to the tag for the specified tutorial number.
+Format: `list attendance tn/TUTORIALNUMBER [coursetg/COURSECODE TUTORIALGROUPID]`
+*  Shows a list of absentees and summary of the attendance records of students corresponding to the course or tutorial group for the specified tutorial number.
+* `COURSECODE` is optional.
+* `TUTORIALGROUPID` is optional, but must be used with `COURSECODE` if present.
 
 Examples:
 *  `list attendance tn/1` Shows a summary of attendance records of all students for Tutorial #1.
-*  `list attendance tn/3 coursetg/CS2103T` Shows a summary of attendance records of the students in CS2103T for Tutorial #3.
+*  `list attendance tn/3 coursetg/CS2103T G01` Shows a summary of attendance records of the students in the course CS2103T and tutorial group G01 for Tutorial #3.
 
 ### Searching for student's contact via keyword : `find`
 
@@ -153,7 +155,7 @@ Examples:
 
 Shows a list of students from a specified tutorial group
 
-Format: `filter add coursetg/COURSECODE [tn/TUTORIALGROUPID]`
+Format: `filter add coursetg/COURSECODE [tg/TUTORIALGROUPID]`
 
 * Filters students that are in the tutorial group specified by `TUTORIALGROUPID` or course specified by `COURSECODE`
 * `COURSECODE` should be a string made up of alphabetical characters and numbers, with no special characters.
@@ -164,14 +166,14 @@ Format: `filter add coursetg/COURSECODE [tn/TUTORIALGROUPID]`
 * `TUTORIALGROUPID` is optional.
 
 Examples:
-* `filter add coursetg/CS2103T tn/G08` returns a list of students from tutorial group G08 for course CS2103T.
+* `filter add coursetg/CS2103T tg/G08` returns a list of students from tutorial group G08 for course CS2103T.
 * `filter add coursetg/CS2103T` returns a list of students in the course CS2103T.
 
 ### Removing filters: `filter remove`
 
 Removes specified applied filter
 
-Format: `filter remove coursetg/COURSECODE [tn/TUTORIALGROUPID]`
+Format: `filter remove coursetg/COURSECODE [tg/TUTORIALGROUPID]`
 
 * Remove the tutorial group filter specified by `TUTORIALGROUPID` or course filter specified by `COURSECODE`
 * `COURSECODE` should be a string made up of alphabetical characters and numbers, with no special characters.
@@ -183,7 +185,7 @@ Format: `filter remove coursetg/COURSECODE [tn/TUTORIALGROUPID]`
 
 Examples:
 * `filter remove` returns the list of all students
-* `filter remove coursetg/CS2103T tn/G08` returns a list of students containing those from tutorial group G08 for course CS2103T.
+* `filter remove coursetg/CS2103T tg/G08` returns a list of students containing those from tutorial group G08 for course CS2103T.
 * `filter remove coursetg/CS2103T` returns a list of students containing those in the course CS2103T.
 
 ### Removing all filters: `filter clear`
@@ -206,8 +208,21 @@ Format: `delete INDEX`
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd person in TAvigator.
+* `list students` followed by `delete 2` deletes the 2nd person in TAvigator.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+
+### Deleting a person : `delete all`
+
+Deletes all students from the specified course or tutorial group of course.
+
+Format: `delete all coursetg/COURSECODE [TUTORIALGROUPID]`
+
+* Deletes the students from the specified course or specified tutorial group from course.
+* `TUTORIALGROUPID` is optional
+
+Examples:
+* `delete all coursetg/CS2030S` deletes all students from the course CS2030S.
+* `delete all coursetg/CS2103T G02` deletes all students from course CS2103T, tutorial group G02.
 
 ### Clearing all entries : `clear`
 
@@ -253,13 +268,13 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
-| Action     | Format, Examples                                                                                |
-|------------|-------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL id/STUDENT_ID [t/COURSE_CODE TUTORIAL_GROUP]...` <br>        |
-| **Clear**  | `clear`                                                                                         |
-| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                             |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [id/STUDENT_ID] [t/COURSE_CODE TUTORIAL_GROUP]...`<br> |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                      |
-| **List**   | `list attendance tn/TUTORIALNO [coursetg/TAG]` `list students`                                  |                                                           |
-| **Help**   | `help`                                                                                          |
-| **Filter**   | `filter [add/delete/clear] [coursetg/COURSECODE] [tn/TUTORIALGROUPID]`                                                                                          |
+| Action     | Format, Examples                                                                                                     |
+|------------|----------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL id/STUDENT_ID [t/COURSECODE TUTORIALGROUPID]...` <br>                             |
+| **Clear**  | `clear`                                                                                                              |
+| **Delete** | `delete all coursetg/COURSECODE [TUTORIALGROUPID]` `delete INDEX` <br> e.g., `delete all coursetg/CS2103T` `delete 3` |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [id/STUDENT_ID] [t/COURSECODE TUTORIALGROUPID]...`<br>                      |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                           |
+| **List**   | `list attendance tn/TUTORIALNO [coursetg/TAG]` `list students`                                                       |                                                           |
+| **Help**   | `help`                                                                                                               |
+| **Filter**   | `filter [add/delete/clear] [coursetg/COURSECODE] [tg/TUTORIALGROUPID]`                                               |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,14 +105,13 @@ Examples:
 
 Shows a summary of attendance records including list of absentees.
 
-Format: `list attendance tn/TUTORIALNUMBER [coursetg/COURSECODE TUTORIALGROUPID]`
-*  Shows a list of absentees and summary of the attendance records of students corresponding to the course or tutorial group for the specified tutorial number.
-* `COURSECODE` is optional.
-* `TUTORIALGROUPID` is optional, but must be used with `COURSECODE` if present.
+Format: `list attendance tn/TUTORIALNUMBER [tg/TUTORIALGROUPID]`
+*  Shows a list of absentees and summary of the attendance records of students corresponding to the tutorial group for the specified tutorial number.
+* `TUTORIALGROUPID` is optional.
 
 Examples:
 *  `list attendance tn/1` Shows a summary of attendance records of all students for Tutorial #1.
-*  `list attendance tn/3 coursetg/CS2103T G01` Shows a summary of attendance records of the students in the course CS2103T and tutorial group G01 for Tutorial #3.
+*  `list attendance tn/3 tg/G01` Shows a summary of attendance records of the students in the tutorial group G01 for Tutorial #3.
 
 ### Searching for student's contact via keyword : `find`
 
@@ -215,14 +214,12 @@ Examples:
 
 Deletes all students from the specified course or tutorial group of course.
 
-Format: `delete all coursetg/COURSECODE [TUTORIALGROUPID]`
+Format: `delete all tg/TUTORIALGROUPID`
 
-* Deletes the students from the specified course or specified tutorial group from course.
-* `TUTORIALGROUPID` is optional
+* Deletes the students from the specified tutorial group.
 
 Examples:
-* `delete all coursetg/CS2030S` deletes all students from the course CS2030S.
-* `delete all coursetg/CS2103T G02` deletes all students from course CS2103T, tutorial group G02.
+* `delete all coursetg/G02` deletes all students from tutorial group G02.
 
 ### Clearing all entries : `clear`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -221,7 +221,7 @@ Format: `delete all [tg/TUTORIALGROUPID]`
 
 Examples:
 * `delete all` deletes all students from the current address book.
-* `delete all coursetg/G02` deletes all students from tutorial group G02.
+* `delete all tg/G02` deletes all students from tutorial group G02.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -10,6 +12,8 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.predicate.ContainsTagPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -19,16 +23,41 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the student identified by the index number used in the displayed person list\n"
+            + "or all students identified by the tag entered.\n"
+            + "Parameters: INDEX (must be a positive integer) || "
+            + "all " + PREFIX_TAG + "TAG\n"
+            + "Example:\n"
+            + COMMAND_WORD + " 1\n"
+            + COMMAND_WORD + " all " + PREFIX_TAG + " CS2103T G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS = "Deleted all contacts from Course %1$s";
+    public static final String MESSAGE_DELETE_TAGGED_WITH_GROUP_SUCCESS = MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS
+            + ", Tutorial Group %2$s";
+
 
     private final Index targetIndex;
+    private final Tag tag;
+    private final ContainsTagPredicate tagPredicate;
 
+    /**
+     * @param targetIndex Index number used in the displayed person list of the target
+     */
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
+        this.tag = null;
+        this.tagPredicate = null;
+    }
+
+    /**
+     * @param tag Course and tutorial groups to delete all students from
+     * @param tagPredicate Predicate used to filter for students in the course and tutorial group
+     */
+    public DeleteCommand(Tag tag, ContainsTagPredicate tagPredicate) {
+        this.targetIndex = null;
+        this.tag = tag;
+        this.tagPredicate = tagPredicate;
     }
 
     @Override
@@ -36,13 +65,32 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (tag == null) {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         }
 
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        model.addFilter(tagPredicate);
+        List<Person> studentsTaggedList = model.getFilteredPersonList();
+        List<Person> copyList = new ArrayList<>(studentsTaggedList);
+
+        for (Person p : copyList) {
+            model.deletePerson(p);
+        }
+
+        model.clearFilters();
+
+        boolean isCourseOnly = tag.getTutorialGroup() == null;
+
+        return isCourseOnly
+                ? new CommandResult(String.format(MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS, tag.getCourseCode()))
+                : new CommandResult(String.format(
+                        MESSAGE_DELETE_TAGGED_WITH_GROUP_SUCCESS, tag.getCourseCode(), tag.getTutorialGroup()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -102,7 +102,12 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+
+        if (tag == null && otherDeleteCommand.tag == null) {
+            return targetIndex.equals(otherDeleteCommand.targetIndex);
+        }
+
+        return tag.equals(otherDeleteCommand.tag);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,19 +24,15 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed person list\n"
-            + "or all students identified by the tag entered.\n"
+            + "or all students identified by the tutorial group ID entered.\n"
             + "Parameters: INDEX (must be a positive integer) || "
-            + "all " + PREFIX_COURSETUTORIAL + "TAG\n"
+            + "all " + PREFIX_TUTORIALGROUP + "TUTORIALGROUPID\n"
             + "Example:\n"
             + COMMAND_WORD + " 1\n"
-            + COMMAND_WORD + " all " + PREFIX_COURSETUTORIAL + " CS2103T G01";
+            + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-    public static final String MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS = "Deleted all contacts from Course %1$s";
-    public static final String MESSAGE_DELETE_TAGGED_WITH_GROUP_SUCCESS = MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS
-            + ", Tutorial Group %2$s";
-
-
+    public static final String MESSAGE_DELETE_TAGGED_SUCCESS = "Deleted all contacts from Tutorial Group %1$s";
     private final Index targetIndex;
     private final Tag tag;
     private final ContainsTagPredicate tagPredicate;
@@ -80,18 +76,12 @@ public class DeleteCommand extends Command {
         List<Person> copyList = new ArrayList<>(studentsTaggedList);
 
         for (Person p : copyList) {
-            // TODO: add ability to delete the specific tag only when there are multiple tags
             model.deletePerson(p);
         }
 
         model.clearFilters();
 
-        boolean isCourseOnly = tag.getTutorialGroup() == null;
-
-        return isCourseOnly
-                ? new CommandResult(String.format(MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS, tag.getCourseCode()))
-                : new CommandResult(String.format(
-                        MESSAGE_DELETE_TAGGED_WITH_GROUP_SUCCESS, tag.getCourseCode(), tag.getTutorialGroup()));
+        return new CommandResult(String.format(MESSAGE_DELETE_TAGGED_SUCCESS, tag.getTagName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,16 +23,16 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the student identified by the index number used in the displayed person list\n"
-            + "or all students identified by the tutorial group ID entered.\n"
+            + ": Deletes the student identified by the index number used in the displayed person list,\n"
+            + " all students identified by the tutorial group ID entered or all students.\n"
             + "Parameters: INDEX (must be a positive integer) || "
-            + "all " + PREFIX_TUTORIALGROUP + "TUTORIALGROUPID\n"
-            + "Example:\n"
-            + COMMAND_WORD + " 1\n"
-            + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
+            + "all [" + PREFIX_TUTORIALGROUP + "TUTORIALGROUPID]\n"
+            + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_TAGGED_SUCCESS = "Deleted all contacts from Tutorial Group %1$s";
+    public static final String MESSAGE_DELETE_NO_TAG_SUCCESS = "Deleted all contacts";
+
     private final Index targetIndex;
     private final Tag tag;
     private final ContainsTagPredicate tagPredicate;
@@ -71,17 +71,23 @@ public class DeleteCommand extends Command {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
         }
 
-        model.addFilter(tagPredicate);
-        List<Person> studentsTaggedList = model.getFilteredPersonList();
-        List<Person> copyList = new ArrayList<>(studentsTaggedList);
+        Tag placeholder = new Tag("PLACEHOLDER");
+        if (!tag.equals(placeholder)) {
+            model.addFilter(tagPredicate);
+        }
 
-        for (Person p : copyList) {
+        List<Person> toDeleteList = model.getFilteredPersonList();
+        List<Person> copyDeleteList = new ArrayList<>(toDeleteList);
+
+        for (Person p : copyDeleteList) {
             model.deletePerson(p);
         }
 
         model.clearFilters();
 
-        return new CommandResult(String.format(MESSAGE_DELETE_TAGGED_SUCCESS, tag.getTagName()));
+        return !tag.equals(placeholder)
+                ? new CommandResult(String.format(MESSAGE_DELETE_TAGGED_SUCCESS, tag.getTagName()))
+                : new CommandResult(String.format(MESSAGE_DELETE_NO_TAG_SUCCESS));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -26,7 +26,7 @@ public class DeleteCommand extends Command {
             + ": Deletes the student identified by the index number used in the displayed person list,\n"
             + " all students identified by the tutorial group ID entered or all students.\n"
             + "Parameters: INDEX (must be a positive integer) || "
-            + "all [" + PREFIX_TUTORIALGROUP + "TUTORIALGROUPID]\n"
+            + "all [" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID]\n"
             + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,10 +26,10 @@ public class DeleteCommand extends Command {
             + ": Deletes the student identified by the index number used in the displayed person list\n"
             + "or all students identified by the tag entered.\n"
             + "Parameters: INDEX (must be a positive integer) || "
-            + "all " + PREFIX_TAG + "TAG\n"
+            + "all " + PREFIX_COURSETUTORIAL + "TAG\n"
             + "Example:\n"
             + COMMAND_WORD + " 1\n"
-            + COMMAND_WORD + " all " + PREFIX_TAG + " CS2103T G01";
+            + COMMAND_WORD + " all " + PREFIX_COURSETUTORIAL + " CS2103T G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_TAGGED_NO_GROUP_SUCCESS = "Deleted all contacts from Course %1$s";
@@ -80,6 +80,7 @@ public class DeleteCommand extends Command {
         List<Person> copyList = new ArrayList<>(studentsTaggedList);
 
         for (Person p : copyList) {
+            // TODO: add ability to delete the specific tag only when there are multiple tags
             model.deletePerson(p);
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,7 +27,8 @@ public class DeleteCommand extends Command {
             + " all students identified by the tutorial group ID entered or all students.\n"
             + "Parameters: INDEX (must be a positive integer) || "
             + "all [" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID]\n"
-            + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
+            + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " all, "
+            + COMMAND_WORD + " all " + PREFIX_TUTORIALGROUP + "G01";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_TAGGED_SUCCESS = "Deleted all contacts from Tutorial Group %1$s";

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALNUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 
 import java.util.Optional;
 
@@ -21,11 +21,11 @@ public class FilterCommand extends Command {
             + ": Add, delete or clear any filters\n"
             + "Parameters: OPERATION (either add, delete or clear) \n"
             + PREFIX_COURSETUTORIAL + "COURSE_CODE "
-            + PREFIX_TUTORIALNUMBER + "TUTORIAL_NUMBER (must be a positive integer) "
+            + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID \n"
             + "Example: " + COMMAND_WORD + " "
-            + "add"
-            + PREFIX_COURSETUTORIAL + "CS2103T"
-            + PREFIX_TUTORIALNUMBER + "1";
+            + "add "
+            + PREFIX_COURSETUTORIAL + "CS2103T "
+            + PREFIX_TUTORIALGROUP + "G01";
 
     public static final String MESSAGE_ADD_SUCCESS = "Added %1$s";
     public static final String MESSAGE_DELETE_SUCCESS = "Removed %1$s";

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -19,10 +19,10 @@ public class ListAttendanceCommand extends ListCommand {
     public static final String COMMAND_WORD = "attendance";
     public static final String MESSAGE_USAGE = "list " + COMMAND_WORD
             + ": Lists summary of attendance and absent students.\n"
-            + "Parameters: \n"
-            + PREFIX_TUTORIALNUMBER + "TUTORIALNUMBER (must be a positive integer) \n"
+            + "Parameters: "
+            + PREFIX_TUTORIALNUMBER + "TUTORIAL_NUMBER (must be a positive integer) "
             + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID]\n"
-            + "Example: list " + COMMAND_WORD + " tn/1 " + " coursetg/CS2103";
+            + "Example: list " + COMMAND_WORD + " tn/1 " + "tg/G02";
     public static final String MESSAGE_SUCCESS = "Listed all absent students:";
 
     private final Index tn;

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -19,10 +19,10 @@ public class ListAttendanceCommand extends ListCommand {
     public static final String COMMAND_WORD = "attendance";
     public static final String MESSAGE_USAGE = "list " + COMMAND_WORD
             + ": Lists summary of attendance and absent students.\n"
-            + "Parameters: "
-            + PREFIX_COURSETUTORIAL + "TAG "
-            + PREFIX_TUTORIALNUMBER + "TUTORIALNUMBER (must be a positive integer)\n"
-            + "Example: list " + COMMAND_WORD + " coursetg/CS2103 " + "tn/1";
+            + "Parameters: \n"
+            + PREFIX_TUTORIALNUMBER + "TUTORIALNUMBER (must be a positive integer) \n"
+            + "(optional:) " + PREFIX_COURSETUTORIAL + "COURSE_CODE (optional:) TUTORIAL_GROUP_ID \n"
+            + "Example: list " + COMMAND_WORD + " tn/1 " + " coursetg/CS2103";
     public static final String MESSAGE_SUCCESS = "Listed all absent students:";
 
     private final Index tn;

--- a/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAttendanceCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALNUMBER;
 
 import seedu.address.commons.core.index.Index;
@@ -21,7 +21,7 @@ public class ListAttendanceCommand extends ListCommand {
             + ": Lists summary of attendance and absent students.\n"
             + "Parameters: \n"
             + PREFIX_TUTORIALNUMBER + "TUTORIALNUMBER (must be a positive integer) \n"
-            + "(optional:) " + PREFIX_COURSETUTORIAL + "COURSE_CODE (optional:) TUTORIAL_GROUP_ID \n"
+            + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID]\n"
             + "Example: list " + COMMAND_WORD + " tn/1 " + " coursetg/CS2103";
     public static final String MESSAGE_SUCCESS = "Listed all absent students:";
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -16,8 +16,8 @@ public abstract class ListCommand extends Command {
             + PREFIX_TUTORIALNUMBER + "TUTORIAL_NUMBER (must be a positive integer) "
             + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID] "
             + "(applicable for list attendance only)\n"
-            + "Example:\n"
-            + COMMAND_WORD + " students\n"
+            + "Example: "
+            + COMMAND_WORD + " students, "
             + COMMAND_WORD + " attendance tn/1 tg/G01";
 
     public ListCommand() {}

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -12,10 +12,10 @@ public abstract class ListCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists either students or attendance.\n"
             + "Parameters: "
-            + "LIST_TYPE (must be either 'students' or 'attendance') "
+            + "LIST_TYPE (must be either 'students' or 'attendance')\n"
+            + "(applicable for list attendance only): "
             + PREFIX_TUTORIALNUMBER + "TUTORIAL_NUMBER (must be a positive integer) "
-            + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID] "
-            + "(applicable for list attendance only)\n"
+            + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID]\n"
             + "Example: "
             + COMMAND_WORD + " students, "
             + COMMAND_WORD + " attendance tn/1 tg/G01";

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALNUMBER;
 
 /**
@@ -13,10 +13,12 @@ public abstract class ListCommand extends Command {
             + ": Lists either students or attendance.\n"
             + "Parameters: "
             + "LIST_TYPE (must be either 'students' or 'attendance') "
-            + PREFIX_COURSETUTORIAL + "TAG "
-            + PREFIX_TUTORIALNUMBER + "TUTORIALNUMBER (must be a positive integer) "
-            + "[applicable for list attendance only]\n"
-            + "Example: " + COMMAND_WORD + " students";
+            + PREFIX_TUTORIALNUMBER + "TUTORIAL_NUMBER (must be a positive integer) "
+            + "[" + PREFIX_TUTORIALGROUP + "TUTORIAL_GROUP_ID] "
+            + "(applicable for list attendance only)\n"
+            + "Example:\n"
+            + COMMAND_WORD + " students\n"
+            + COMMAND_WORD + " attendance tn/1 tg/G01";
 
     public ListCommand() {}
 }

--- a/src/main/java/seedu/address/logic/commands/ListStudentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListStudentsCommand.java
@@ -11,7 +11,7 @@ public class ListStudentsCommand extends ListCommand {
 
     public static final String COMMAND_WORD = "students";
     public static final String MESSAGE_USAGE = "list " + COMMAND_WORD
-            + ": Lists students.\n"
+            + ": Lists all students.\n"
             + "Example: list " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Listed all students!";
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ID = new Prefix("id/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_COURSETUTORIAL = new Prefix("coursetg/");
+    public static final Prefix PREFIX_TUTORIALGROUP = new Prefix("tg/");
     public static final Prefix PREFIX_TUTORIALNUMBER = new Prefix("tn/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -32,14 +32,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             }
         }
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COURSETUTORIAL);
 
-        if (!argMultimap.getValue(PREFIX_TAG).isPresent()) {
+        if (!argMultimap.getValue(PREFIX_COURSETUTORIAL).isPresent()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-        String tagName = argMultimap.getValue(PREFIX_TAG).get();
+        String tagName = argMultimap.getValue(PREFIX_COURSETUTORIAL).get();
         Tag tag = ParserUtil.parseTag(tagName);
 
         return new DeleteCommand(tag, new ContainsTagPredicate(tag));

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -22,7 +22,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     public DeleteCommand parse(String args) throws ParseException {
 
-        if (!args.trim().startsWith("all")) {
+        String trimmedArgs = args.trim();
+        if (!trimmedArgs.startsWith("all")) {
             try {
                 Index index = ParserUtil.parseIndex(args);
                 return new DeleteCommand(index);
@@ -34,9 +35,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIALGROUP);
 
-        if (!argMultimap.getValue(PREFIX_TUTORIALGROUP).isPresent()) {
+        if (trimmedArgs.equals("all")) {
             Tag tag = new Tag("PLACEHOLDER");
             return new DeleteCommand(tag, new ContainsTagPredicate(tag));
+        }
+
+        if (!argMultimap.getValue(PREFIX_TUTORIALGROUP).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
         String tagName = argMultimap.getValue(PREFIX_TUTORIALGROUP).get();

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -22,7 +22,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     public DeleteCommand parse(String args) throws ParseException {
 
-        if (!args.startsWith(" all")) {
+        if (!args.trim().startsWith("all")) {
             try {
                 Index index = ParserUtil.parseIndex(args);
                 return new DeleteCommand(index);
@@ -32,14 +32,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             }
         }
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COURSETUTORIAL);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIALGROUP);
 
-        if (!argMultimap.getValue(PREFIX_COURSETUTORIAL).isPresent()) {
+        if (!argMultimap.getValue(PREFIX_TUTORIALGROUP).isPresent()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-        String tagName = argMultimap.getValue(PREFIX_COURSETUTORIAL).get();
+        String tagName = argMultimap.getValue(PREFIX_TUTORIALGROUP).get();
         Tag tag = ParserUtil.parseTag(tagName);
 
         return new DeleteCommand(tag, new ContainsTagPredicate(tag));

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -35,8 +35,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TUTORIALGROUP);
 
         if (!argMultimap.getValue(PREFIX_TUTORIALGROUP).isPresent()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            Tag tag = new Tag("PLACEHOLDER");
+            return new DeleteCommand(tag, new ContainsTagPredicate(tag));
         }
 
         String tagName = argMultimap.getValue(PREFIX_TUTORIALGROUP).get();

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.predicate.ContainsTagPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -16,14 +19,29 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
-    }
 
+    public DeleteCommand parse(String args) throws ParseException {
+
+        if (!args.startsWith(" all")) {
+            try {
+                Index index = ParserUtil.parseIndex(args);
+                return new DeleteCommand(index);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            }
+        }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
+        if (!argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        String tagName = argMultimap.getValue(PREFIX_TAG).get();
+        Tag tag = ParserUtil.parseTag(tagName);
+
+        return new DeleteCommand(tag, new ContainsTagPredicate(tag));
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALNUMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 
 import java.util.stream.Stream;
 
@@ -24,7 +24,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TUTORIALNUMBER, PREFIX_COURSETUTORIAL);
+                ArgumentTokenizer.tokenize(args, PREFIX_TUTORIALGROUP, PREFIX_COURSETUTORIAL);
 
         FilterOperation operation;
 
@@ -45,11 +45,11 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             }
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TUTORIALNUMBER, PREFIX_COURSETUTORIAL);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TUTORIALGROUP, PREFIX_COURSETUTORIAL);
 
         return new FilterCommand(operation,
                 argMultimap.getValue(PREFIX_COURSETUTORIAL),
-                argMultimap.getValue(PREFIX_TUTORIALNUMBER));
+                argMultimap.getValue(PREFIX_TUTORIALGROUP));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSETUTORIAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALGROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIALNUMBER;
 
 import java.util.regex.Matcher;
@@ -44,10 +44,10 @@ public class ListCommandParser implements Parser<ListCommand> {
         Index tn = Index.fromZeroBased(1);
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(arguments, PREFIX_COURSETUTORIAL, PREFIX_TUTORIALNUMBER);
+                ArgumentTokenizer.tokenize(arguments, PREFIX_TUTORIALGROUP, PREFIX_TUTORIALNUMBER);
 
-        if (argMultimap.getValue(PREFIX_COURSETUTORIAL).isPresent()) {
-            String tgValue = argMultimap.getValue(PREFIX_COURSETUTORIAL).get();
+        if (argMultimap.getValue(PREFIX_TUTORIALGROUP).isPresent()) {
+            String tgValue = argMultimap.getValue(PREFIX_TUTORIALGROUP).get();
             tag = ParserUtil.parseTag(tgValue);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -57,10 +57,8 @@ public class ListCommandParser implements Parser<ListCommand> {
         }
 
         switch (commandWord) {
-
         case ListStudentsCommand.COMMAND_WORD:
             return new ListStudentsCommand();
-
         case ListAttendanceCommand.COMMAND_WORD:
             if (!argMultimap.getValue(PREFIX_TUTORIALNUMBER).isPresent()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -69,8 +67,7 @@ public class ListCommandParser implements Parser<ListCommand> {
             return new ListAttendanceCommand(tag, tn, new ContainsTagPredicate(tag),
                     new AbsentFromTutorialPredicate(tn, tag));
         default:
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ListCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -56,16 +56,22 @@ public class ListCommandParser implements Parser<ListCommand> {
             tn = ParserUtil.parseIndex(tnValue);
         }
 
+        System.out.println(commandWord);
+
         switch (commandWord) {
-        case ListStudentsCommand.COMMAND_WORD:
-            return new ListStudentsCommand();
         case ListAttendanceCommand.COMMAND_WORD:
+            System.out.println(commandWord);
             if (!argMultimap.getValue(PREFIX_TUTORIALNUMBER).isPresent()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                         ListAttendanceCommand.MESSAGE_USAGE));
             }
             return new ListAttendanceCommand(tag, tn, new ContainsTagPredicate(tag),
                     new AbsentFromTutorialPredicate(tn, tag));
+        case ListStudentsCommand.COMMAND_WORD:
+            if (arguments.isEmpty()) {
+                return new ListStudentsCommand();
+            }
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListStudentsCommand.MESSAGE_USAGE));
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
+++ b/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
@@ -23,20 +23,24 @@ public class AbsentFromTutorialPredicate extends SerializablePredicate {
      */
     public AbsentFromTutorialPredicate(Index index, Tag tag) {
         super(person -> {
+            // TODO: CHANGE TO FIT MAP<LIST>
             if (index.getOneBased() > person.getAttendanceRecords().size()) {
                 return false;
             }
 
+            boolean isCourseOnly = tag.getTutorialGroup() == null;
+
             Tag placeholder = new Tag("PLACEHOLDER");
             if (tag.equals(placeholder)) {
+                // TODO: CHANGE TO FIT MAP<LIST>
                 return !person.getAttendanceRecords().get(index.getZeroBased()).isPresent();
             }
 
             // Implicit else
             return person.getTags().stream().anyMatch(personTag -> (
-                    tag.getTutorialGroup() == null
-                            ? personTag.getCourseCode().equals(tag.getCourseCode())
+                    isCourseOnly ? personTag.getCourseCode().equals(tag.getCourseCode())
                             : personTag.getTagName().equals(tag.getTagName()))
+                    // TODO: CHANGE TO FIT MAP<LIST>
                     && !person.getAttendanceRecords().get(index.getZeroBased()).isPresent());
         });
         this.index = index;

--- a/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
+++ b/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -23,25 +24,19 @@ public class AbsentFromTutorialPredicate extends SerializablePredicate {
      */
     public AbsentFromTutorialPredicate(Index index, Tag tag) {
         super(person -> {
-            // TODO: CHANGE TO FIT MAP<LIST>
             if (index.getOneBased() > person.getAttendanceRecords().size()) {
                 return false;
             }
 
-            boolean isCourseOnly = tag.getTutorialGroup() == null;
-
             Tag placeholder = new Tag("PLACEHOLDER");
             if (tag.equals(placeholder)) {
-                // TODO: CHANGE TO FIT MAP<LIST>
                 return !person.getAttendanceRecords().get(index.getZeroBased()).isPresent();
             }
 
             // Implicit else
-            return person.getTags().stream().anyMatch(personTag -> (
-                    isCourseOnly ? personTag.getCourseCode().equals(tag.getCourseCode())
-                            : personTag.getTagName().equals(tag.getTagName()))
-                    // TODO: CHANGE TO FIT MAP<LIST>
-                    && !person.getAttendanceRecords().get(index.getZeroBased()).isPresent());
+            return person.getTags().stream().anyMatch(
+                    personTag -> StringUtil.containsWordIgnoreCase(personTag.getTagName(), tag.getTagName()))
+                    && !person.getAttendanceRecords().get(index.getZeroBased()).isPresent();
         });
         this.index = index;
         this.tag = tag;

--- a/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
+++ b/src/main/java/seedu/address/model/predicate/AbsentFromTutorialPredicate.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -34,9 +33,11 @@ public class AbsentFromTutorialPredicate extends SerializablePredicate {
             }
 
             // Implicit else
-            return person.getTags().stream()
-                    .anyMatch(personTag -> StringUtil.containsWordIgnoreCase(personTag.getTagName(), tag.getTagName()))
-                    && !person.getAttendanceRecords().get(index.getZeroBased()).isPresent();
+            return person.getTags().stream().anyMatch(personTag -> (
+                    tag.getTutorialGroup() == null
+                            ? personTag.getCourseCode().equals(tag.getCourseCode())
+                            : personTag.getTagName().equals(tag.getTagName()))
+                    && !person.getAttendanceRecords().get(index.getZeroBased()).isPresent());
         });
         this.index = index;
         this.tag = tag;

--- a/src/main/java/seedu/address/model/predicate/ContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/predicate/ContainsTagPredicate.java
@@ -3,7 +3,6 @@ package seedu.address.model.predicate;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -19,8 +18,10 @@ public class ContainsTagPredicate extends SerializablePredicate {
      * @param tag Tag to check for in a person.
      */
     public ContainsTagPredicate(Tag tag) {
-        super(person -> person.getTags().stream().anyMatch(personTag ->
-                StringUtil.containsWordIgnoreCase(personTag.getTagName(), tag.getTagName())));
+        super(person -> person.getTags().stream().anyMatch(
+                personTag -> tag.getTutorialGroup() == null
+                        ? personTag.getCourseCode().equals(tag.getCourseCode())
+                        : personTag.getTagName().equals(tag.getTagName())));
         this.tag = tag;
     }
 

--- a/src/main/java/seedu/address/model/predicate/ContainsTagPredicate.java
+++ b/src/main/java/seedu/address/model/predicate/ContainsTagPredicate.java
@@ -3,6 +3,7 @@ package seedu.address.model.predicate;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -19,9 +20,7 @@ public class ContainsTagPredicate extends SerializablePredicate {
      */
     public ContainsTagPredicate(Tag tag) {
         super(person -> person.getTags().stream().anyMatch(
-                personTag -> tag.getTutorialGroup() == null
-                        ? personTag.getCourseCode().equals(tag.getCourseCode())
-                        : personTag.getTagName().equals(tag.getTagName())));
+                personTag -> StringUtil.containsWordIgnoreCase(personTag.getTagName(), tag.getTagName())));
         this.tag = tag;
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,7 +6,7 @@
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "id": "A1234567Y",
-    "tags" : [ "CS2040S" ]
+    "tags" : [ "G02" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -10,6 +10,9 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -18,7 +21,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.predicate.ContainsTagPredicate;
 import seedu.address.model.predicate.SerializablePredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -38,6 +43,23 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_allWithNoTag_success() {
+        Tag placeholder = new Tag("PLACEHOLDER");
+        ContainsTagPredicate pred = new ContainsTagPredicate(placeholder);
+        DeleteCommand deleteCommand = new DeleteCommand(placeholder, pred);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_NO_TAG_SUCCESS);
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        List<Person> personsToDelete = new ArrayList<>(expectedModel.getFilteredPersonList());
+
+        for (Person p : personsToDelete) {
+            expectedModel.deletePerson(p);
+        }
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -62,6 +62,7 @@ public class DeleteCommandTest {
                 Messages.format(personToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAttendanceCommandTest.java
@@ -38,8 +38,8 @@ public class ListAttendanceCommandTest {
 
     @Test
     public void equals() {
-        Tag firstTag = new Tag("CS2030S");
-        Tag secondTag = new Tag("CS2040S");
+        Tag firstTag = new Tag("G10");
+        Tag secondTag = new Tag("G01");
         Index firstIndex = Index.fromOneBased(1);
         Index secondIndex = Index.fromOneBased(2);
 
@@ -72,7 +72,7 @@ public class ListAttendanceCommandTest {
     public void execute_listAttendanceWithTag_success() {
         ALICE.addAttendance(new Attendance(LocalDate.now(), false));
 
-        Tag tag = new Tag("CS2040S");
+        Tag tag = new Tag("G02");
         Index index = Index.fromOneBased(1);
         ListAttendanceCommand command = new ListAttendanceCommand(tag, index,
                 new ContainsTagPredicate(tag), new AbsentFromTutorialPredicate(index, tag));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -96,13 +96,13 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " add coursetg/CS2103T") instanceof FilterCommand);
         assertTrue(parser.parseCommand(
-                FilterCommand.COMMAND_WORD + " add coursetg/CS2103T tn/1") instanceof FilterCommand);
+                FilterCommand.COMMAND_WORD + " add coursetg/CS2103T tg/1") instanceof FilterCommand);
         assertTrue(parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " delete coursetg/CS2103T") instanceof FilterCommand);
         assertTrue(parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " delete coursetg/CS2103T") instanceof FilterCommand);
         assertTrue(parser.parseCommand(
-                FilterCommand.COMMAND_WORD + " delete coursetg/CS2103T tn/1") instanceof FilterCommand);
+                FilterCommand.COMMAND_WORD + " delete coursetg/CS2103T tg/1") instanceof FilterCommand);
         assertTrue(parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " clear") instanceof FilterCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -8,6 +8,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.predicate.ContainsTagPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -23,6 +25,12 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+
+        Tag placeholder = new Tag("PLACEHOLDER");
+        assertParseSuccess(parser, "all", new DeleteCommand(placeholder, new ContainsTagPredicate(placeholder)));
+
+        Tag tag = new Tag("G10");
+        assertParseSuccess(parser, "all tg/G10", new DeleteCommand(tag, new ContainsTagPredicate(tag)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -36,5 +36,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "all 123", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -21,7 +21,7 @@ public class FilterCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         assertParseFailure(parser, " ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "add tn/2",
+        assertParseFailure(parser, "add tg/2",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -19,15 +19,28 @@ public class ListCommandParserTest {
     private ListCommandParser parser = new ListCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
+    public void parse_emptyArgs_throwsParseException() {
         assertParseFailure(parser, "     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_listInvalidArg_throwsParseException() {
+    public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "  abc   ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_listStudentsInvalidArgs_throwsParseException() {
+        assertParseFailure(parser, "students 123",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListStudentsCommand.MESSAGE_USAGE));
+    }
+    @Test
+    public void parse_listAttendanceInvalidArgs_throwsParseException() {
+        assertParseFailure(parser, "  attendance  tg/G02 ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "  attendance  ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -42,25 +55,16 @@ public class ListCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArg_throwsParseException() {
-        // no leading and trailing whitespaces
+    public void parse_validArgs_returnsListAttendanceCommand() {
+        // with leading and trailing whitespaces
         Tag tag = new Tag("G02");
         Index index = Index.fromOneBased(1);
         ListAttendanceCommand expectedListAttendanceCommand = new ListAttendanceCommand(tag, index,
                 new ContainsTagPredicate(tag), new AbsentFromTutorialPredicate(index, tag));
-        assertParseSuccess(parser, " attendance tg/G02 tn/1", expectedListAttendanceCommand);
+        assertParseSuccess(parser, " attendance tg/G02 tn/1 ", expectedListAttendanceCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, "    attendance      tg/     G02     tn/    1      ",
                 expectedListAttendanceCommand);
     }
-
-    @Test
-    public void parse_listAttendanceInvalidArgs_throwsParseException() {
-        assertParseFailure(parser, "  attendance  tg/G02 ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "  attendance  ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));
-    }
-
 }

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -44,20 +44,20 @@ public class ListCommandParserTest {
     @Test
     public void parse_invalidArg_throwsParseException() {
         // no leading and trailing whitespaces
-        Tag tag = new Tag("CS2103T");
+        Tag tag = new Tag("G02");
         Index index = Index.fromOneBased(1);
         ListAttendanceCommand expectedListAttendanceCommand = new ListAttendanceCommand(tag, index,
                 new ContainsTagPredicate(tag), new AbsentFromTutorialPredicate(index, tag));
-        assertParseSuccess(parser, " attendance coursetg/CS2103T tn/1", expectedListAttendanceCommand);
+        assertParseSuccess(parser, " attendance tg/G02 tn/1", expectedListAttendanceCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "    attendance      coursetg/     CS2103T     tn/    1      ",
+        assertParseSuccess(parser, "    attendance      tg/     G02     tn/    1      ",
                 expectedListAttendanceCommand);
     }
 
     @Test
     public void parse_listAttendanceInvalidArgs_throwsParseException() {
-        assertParseFailure(parser, "  attendance  coursetg/CS2103T ",
+        assertParseFailure(parser, "  attendance  tg/G02 ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "  attendance  ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListAttendanceCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/model/predicate/AbsentFromTutorialPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicate/AbsentFromTutorialPredicateTest.java
@@ -19,22 +19,22 @@ public class AbsentFromTutorialPredicateTest {
     public void test_absentFromTutorialNum_returnsTrue() {
         // With person absent
         AbsentFromTutorialPredicate predicate = new AbsentFromTutorialPredicate(
-                Index.fromOneBased(1), new Tag("CS2103T"));
-        Person person = new PersonBuilder().withTags("CS2103T").build();
+                Index.fromOneBased(1), new Tag("CS2103T G02"));
+        Person person = new PersonBuilder().withTags("CS2103T G02").build();
         person.addAttendance(new Attendance(LocalDate.now(), false));
         assertTrue(predicate.test(person));
 
-        // Ignore case
+        // With no tag
         AbsentFromTutorialPredicate predicate2 = new AbsentFromTutorialPredicate(
-                Index.fromOneBased(1), new Tag("CS2103T"));
-        Person person2 = new PersonBuilder().withTags("Cs2103t").build();
+                Index.fromOneBased(1), new Tag("PLACEHOLDER"));
+        Person person2 = new PersonBuilder().withTags("CS2103T").build();
         person2.addAttendance(new Attendance(LocalDate.now(), false));
         assertTrue(predicate2.test(person2));
 
-        // With no tag
+        // With no tutorial group number
         AbsentFromTutorialPredicate predicate3 = new AbsentFromTutorialPredicate(
-                Index.fromOneBased(1), new Tag("PLACEHOLDER"));
-        Person person3 = new PersonBuilder().withTags("CS2103T").build();
+                Index.fromOneBased(1), new Tag("CS2103T"));
+        Person person3 = new PersonBuilder().withTags("CS2103T G10").build();
         person3.addAttendance(new Attendance(LocalDate.now(), false));
         assertTrue(predicate3.test(person3));
     }

--- a/src/test/java/seedu/address/model/predicate/AbsentFromTutorialPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicate/AbsentFromTutorialPredicateTest.java
@@ -19,24 +19,17 @@ public class AbsentFromTutorialPredicateTest {
     public void test_absentFromTutorialNum_returnsTrue() {
         // With person absent
         AbsentFromTutorialPredicate predicate = new AbsentFromTutorialPredicate(
-                Index.fromOneBased(1), new Tag("CS2103T G02"));
-        Person person = new PersonBuilder().withTags("CS2103T G02").build();
+                Index.fromOneBased(1), new Tag("G02"));
+        Person person = new PersonBuilder().withTags("G02").build();
         person.addAttendance(new Attendance(LocalDate.now(), false));
         assertTrue(predicate.test(person));
 
         // With no tag
         AbsentFromTutorialPredicate predicate2 = new AbsentFromTutorialPredicate(
                 Index.fromOneBased(1), new Tag("PLACEHOLDER"));
-        Person person2 = new PersonBuilder().withTags("CS2103T").build();
+        Person person2 = new PersonBuilder().withTags("G10").build();
         person2.addAttendance(new Attendance(LocalDate.now(), false));
         assertTrue(predicate2.test(person2));
-
-        // With no tutorial group number
-        AbsentFromTutorialPredicate predicate3 = new AbsentFromTutorialPredicate(
-                Index.fromOneBased(1), new Tag("CS2103T"));
-        Person person3 = new PersonBuilder().withTags("CS2103T G10").build();
-        person3.addAttendance(new Attendance(LocalDate.now(), false));
-        assertTrue(predicate3.test(person3));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -25,7 +25,7 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com").withPhone("94351253")
-            .withId("A1234567Y").withTags("CS2040S").build();
+            .withId("A1234567Y").withTags("G02").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withId("A1234567Z").withTags("owesMoney", "friends").build();


### PR DESCRIPTION

Addresses issue #28 

Changes
- Edited AbsentFromTutorialPredicate and ContainsTagPredicate to be able to accept whitespace in Tag
- Modified DeleteCommandParser to allow for deleting all students from specified course / specified tutorial group from course
- Modified DeleteCommand
- Updated UserGuide.md
- Added test cases for DeleteCommandParser

Todo:
- Write test cases for DeleteCommand

