### PR TITLE
Enhance MarkAttendanceCommand and MarkAttendanceCommandParser

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -89,17 +89,22 @@ Examples:
 
 ### Marking attendance of student: `mark`
 
-Format: `mark /name STUDENTNAME | /id STUDENTID /attendance ATTENDANCE`
-* Marks the attendance of a student corresponding to the student name or student ID.
+Format: `mark /name STUDENTNAME[, STUDENTNAME] | /id STUDENTID[, STUDENTID] /attendance ATTENDANCE`
+* Marks the attendance of one or more student corresponding to the student name or student ID.
+* To mark attendance for multiple students, provide a comma-separated list of student names or student IDs.
 * `STUDENTNAME` should be a string made up of alphabetical characters, with no numbers or special characters.
 * `STUDENTID` should be a string made up of alphabetical characters, with no special characters or space.
 * `ATTENDANCE` should only be 0 or 1, where 0 indicates student is absent and 1 indicates student is present.
 
 Examples:
 * `mark /name Zong Jin /attendance 1` Marks student named, Zong Jin, as present.
+* `mark /name Zong Jin, Fu Yiqiao /attendance 1` Marks students named, Zong Jin and Fu Yiqiao, as present.
 * `mark /name Zong Jin /attendance 0` Marks student named, Zong Jin, as absent.
+* `mark /name Zong Jin, Fu Yiqiao /attendance 0` Marks students named, Zong Jin and Fu Yiqiao, as absent.
 * `mark /id A0123456E /attendance 1` Marks student with student ID, A0123456E, as present.
+* `mark /id A0123456E, A0123457E /attendance 1` Marks students with student IDs, A0123456E and A0123457E, as present.
 * `mark /id A0123456E /attendance 0` Marks student with student ID, A0123456E, as absent.
+* `mark /id A0123456E, A0123457E /attendance 0` Marks students with student IDs, A0123456E and A0123457E, as absent.
 
 ### Viewing summary of attendance : `list attendance`
 

--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -21,6 +22,7 @@ public class MarkAttendanceCommand extends Command {
             + "/attendance ATTENDANCE "
             + "Example: " + COMMAND_WORD + " /name Zong Jin /attendance 1";
     public static final String MESSAGE_SUCCESS = "Attendance marked for person: ";
+    public static final String MESSAGE_UPDATED_SUCCESS = "Attendance updated for person: ";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Person not found.";
     private final String identifier; // This can be either studentName or studentID
     private final boolean isPresent;
@@ -54,11 +56,21 @@ public class MarkAttendanceCommand extends Command {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
         }
 
-        // TODO - Possibly implement module inclusion for attendance and modify UG appropriately
-        Attendance attendance = new Attendance(date, isPresent);
-        targetPerson.addAttendance(attendance);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS + "%s", targetPerson.getName()));
+        Optional<Attendance> existingAttendance = targetPerson.getAttendanceForCurrentWeek();
+
+        if (existingAttendance.isPresent()) {
+            // Modify the existing attendance record
+            Attendance attendance = existingAttendance.get();
+            attendance.setAttendance(isPresent);
+            return new CommandResult(String.format(MESSAGE_UPDATED_SUCCESS + "%s", targetPerson.getName()));
+
+        } else {
+            // Add a new attendance record for the current week
+            Attendance newAttendance = new Attendance(date, isPresent);
+            targetPerson.addAttendance(newAttendance);
+            return new CommandResult(String.format(MESSAGE_SUCCESS + "%s", targetPerson.getName()));
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkAttendanceCommandParser.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.MarkAttendanceCommand;
@@ -35,17 +37,23 @@ public class MarkAttendanceCommandParser implements Parser<MarkAttendanceCommand
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkAttendanceCommand.MESSAGE_USAGE));
         }
 
-        String identifier;
+        List<String> identifiers = new ArrayList<>();
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            identifier = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).fullName;
+            String[] names = argMultimap.getValue(PREFIX_NAME).get().split(",");
+            for (String name : names) {
+                identifiers.add(ParserUtil.parseName(name.trim()).fullName);
+            }
         } else {
-            identifier = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get()).value;
+            String[] ids = argMultimap.getValue(PREFIX_ID).get().split(",");
+            for (String id : ids) {
+                identifiers.add(ParserUtil.parseId(id.trim()).value);
+            }
         }
 
         boolean isPresent = ParserUtil.parseAttendance(argMultimap.getValue(PREFIX_ATTENDANCE).get());
         LocalDate date = LocalDate.now(); // Assuming attendance is marked for the current date
 
-        return new MarkAttendanceCommand(identifier, isPresent, date);
+        return new MarkAttendanceCommand(identifiers, isPresent, date);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Attendance.java
+++ b/src/main/java/seedu/address/model/person/Attendance.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import java.time.LocalDate;
 import java.util.Objects;
+import java.time.temporal.ChronoField;
 
 /**
  * Represents a Student's attendance in the address book.
@@ -31,6 +32,17 @@ public class Attendance {
      */
     public LocalDate getDate() {
         return date;
+    }
+
+    /**
+     * Checks if the given date is in the same week as the date of this Attendance object.
+     *
+     * @param otherDate The date to be checked.
+     * @return True if the given date is in the same week, otherwise false.
+     */
+    public boolean isSameWeek(LocalDate otherDate) {
+        return this.date.get(ChronoField.ALIGNED_WEEK_OF_YEAR) == otherDate.get(ChronoField.ALIGNED_WEEK_OF_YEAR)
+                && this.date.getYear() == otherDate.getYear();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Attendance.java
+++ b/src/main/java/seedu/address/model/person/Attendance.java
@@ -1,8 +1,8 @@
 package seedu.address.model.person;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import java.time.temporal.ChronoField;
+import java.util.Objects;
 
 /**
  * Represents a Student's attendance in the address book.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,11 +2,13 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -60,6 +62,19 @@ public class Person {
     public List<Attendance> getAttendanceRecords() {
         return attendanceRecords;
     }
+
+    /**
+     * Retrieves the Attendance object for the current week, if it exists.
+     *
+     * @return An Optional containing the Attendance object for the current week, or an empty Optional if not found.
+     */
+    public Optional<Attendance> getAttendanceForCurrentWeek() {
+        LocalDate currentDate = LocalDate.now();
+        return attendanceRecords.stream()
+                .filter(attendance -> attendance.isSameWeek(currentDate))
+                .findFirst();
+    }
+
 
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_PERSON_NOT_FOUND;
 import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_UPDATED_SUCCESS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.time.LocalDate;
@@ -86,6 +87,39 @@ public class MarkAttendanceCommandTest {
         MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234555E", true, LocalDate.now());
 
         assertCommandFailure(markAttendanceCommand, model, MESSAGE_PERSON_NOT_FOUND);
+    }
+
+    /**
+     * Tests if the attendance of a person is correctly updated when an attendance record for the current week already exists.
+     */
+    @Test
+    public void execute_personWithExistingAttendance_updatesAttendance() {
+        Person amy = new PersonBuilder().build();
+        model.addPerson(amy);
+        amy.addAttendance(new Attendance(LocalDate.now(), false));
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234567E", true, LocalDate.now());
+
+        String expectedMessage = String.format(MESSAGE_UPDATED_SUCCESS + "%s", amy.getName());
+
+        Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
+        expectedModel.addPerson(expectedAmy);
+        assertCommandSuccess(markAttendanceCommand, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Tests if the attendance of a person is correctly added when no attendance record for the current week exists.
+     */
+    @Test
+    public void execute_personWithoutExistingAttendance_addsAttendance() {
+        Person amy = new PersonBuilder().build();
+        model.addPerson(amy);
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234567E", true, LocalDate.now());
+
+        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s", amy.getName());
+
+        Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
+        expectedModel.addPerson(expectedAmy);
+        assertCommandSuccess(markAttendanceCommand, model, expectedMessage, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.MarkAttendanceCommand.MESSAGE_UPDATED
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +39,10 @@ public class MarkAttendanceCommandTest {
     public void execute_marksAttendanceWithValidPersonName_success() {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("Amy Bee", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("Amy Bee"), true,
+                LocalDate.now());
 
-        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s", amy.getName());
+        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s\n", amy.getName());
 
         Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
         expectedModel.addPerson(expectedAmy);
@@ -55,9 +57,10 @@ public class MarkAttendanceCommandTest {
     public void execute_marksAttendanceWithValidPersonID_success() {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234567E", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("A1234567E"), true,
+                LocalDate.now());
 
-        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s", amy.getName());
+        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s\n", amy.getName());
 
         Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
         expectedModel.addPerson(expectedAmy);
@@ -72,7 +75,8 @@ public class MarkAttendanceCommandTest {
     public void execute_marksAttendanceWithInvalidPersonName_failure() {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("Bobby", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("Bobby"), true,
+                LocalDate.now());
 
         assertCommandFailure(markAttendanceCommand, model, MESSAGE_PERSON_NOT_FOUND);
     }
@@ -84,7 +88,8 @@ public class MarkAttendanceCommandTest {
     public void execute_marksAttendanceWithInvalidPersonID_failure() {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234555E", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("A1234555E"), true,
+                LocalDate.now());
 
         assertCommandFailure(markAttendanceCommand, model, MESSAGE_PERSON_NOT_FOUND);
     }
@@ -97,9 +102,10 @@ public class MarkAttendanceCommandTest {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
         amy.addAttendance(new Attendance(LocalDate.now(), false));
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234567E", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("A1234567E"), true,
+                LocalDate.now());
 
-        String expectedMessage = String.format(MESSAGE_UPDATED_SUCCESS + "%s", amy.getName());
+        String expectedMessage = String.format(MESSAGE_UPDATED_SUCCESS + "%s\n", amy.getName());
 
         Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
         expectedModel.addPerson(expectedAmy);
@@ -113,9 +119,10 @@ public class MarkAttendanceCommandTest {
     public void execute_personWithoutExistingAttendance_addsAttendance() {
         Person amy = new PersonBuilder().build();
         model.addPerson(amy);
-        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand("A1234567E", true, LocalDate.now());
+        MarkAttendanceCommand markAttendanceCommand = new MarkAttendanceCommand(List.of("A1234567E"), true,
+            LocalDate.now());
 
-        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s", amy.getName());
+        String expectedMessage = String.format(MESSAGE_SUCCESS + "%s\n", amy.getName());
 
         Person expectedAmy = new PersonBuilder(amy).withAttendance(new Attendance(LocalDate.now(), true)).build();
         expectedModel.addPerson(expectedAmy);
@@ -128,15 +135,16 @@ public class MarkAttendanceCommandTest {
     @Test
     public void equals() {
 
-        MarkAttendanceCommand markAmyAttendanceFirstCommand = new MarkAttendanceCommand("Amy Bee", true,
+        MarkAttendanceCommand markAmyAttendanceFirstCommand = new MarkAttendanceCommand(List.of("Amy Bee"), true,
                 LocalDate.now());
-        MarkAttendanceCommand markBobAttendanceCommand = new MarkAttendanceCommand("Bob", false, LocalDate.now());
+        MarkAttendanceCommand markBobAttendanceCommand = new MarkAttendanceCommand(List.of("Bob"), false,
+                LocalDate.now());
 
         // same object -> returns true
         assertEquals(markAmyAttendanceFirstCommand, markAmyAttendanceFirstCommand);
 
         // same values -> returns true
-        MarkAttendanceCommand markAmyAttendanceFirstCommandCopy = new MarkAttendanceCommand("Amy Bee", true,
+        MarkAttendanceCommand markAmyAttendanceFirstCommandCopy = new MarkAttendanceCommand(List.of("Amy Bee"), true,
                 LocalDate.now());
         assertEquals(markAmyAttendanceFirstCommand, markAmyAttendanceFirstCommandCopy);
 

--- a/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAttendanceCommandTest.java
@@ -95,7 +95,8 @@ public class MarkAttendanceCommandTest {
     }
 
     /**
-     * Tests if the attendance of a person is correctly updated when an attendance record for the current week already exists.
+     * Tests if the attendance of a person is correctly updated when an attendance
+     * record for the current week already exists.
      */
     @Test
     public void execute_personWithExistingAttendance_updatesAttendance() {

--- a/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkAttendanceCommandParserTest.java
@@ -2,11 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +31,8 @@ public class MarkAttendanceCommandParserTest {
     @Test
     public void parse_validArgsWithName_returnsMarkAttendanceCommand() {
         String userInput = " /name " + VALID_NAME_AMY + " /attendance 1";
-        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(VALID_NAME_AMY, true, LocalDate.now());
+        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(List.of(VALID_NAME_AMY), true,
+                LocalDate.now());
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -38,7 +42,30 @@ public class MarkAttendanceCommandParserTest {
     @Test
     public void parse_validArgsWithId_returnsMarkAttendanceCommand() {
         String userInput = " /id " + VALID_ID_AMY + " /attendance 0";
-        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(VALID_ID_AMY, false, LocalDate.now());
+        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(List.of(VALID_ID_AMY), false,
+                LocalDate.now());
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the parsing of valid arguments using multiple names to return a {@code MarkAttendanceCommand}.
+     */
+    @Test
+    public void parse_validArgsWithMultipleNames_returnsMarkAttendanceCommand() {
+        String userInput = " /name " + VALID_NAME_AMY + "," + VALID_NAME_BOB + " /attendance 1";
+        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(List.of(VALID_NAME_AMY, VALID_NAME_BOB), true,
+                LocalDate.now());
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests the parsing of valid arguments using multiple IDs to return a {@code MarkAttendanceCommand}.
+     */
+    @Test
+    public void parse_validArgsWithMultipleIds_returnsMarkAttendanceCommand() {
+        String userInput = " /id " + VALID_ID_AMY + "," + VALID_ID_BOB + " /attendance 0";
+        MarkAttendanceCommand expectedCommand = new MarkAttendanceCommand(List.of(VALID_ID_AMY, VALID_ID_BOB), false,
+                LocalDate.now());
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/model/person/AttendanceTest.java
+++ b/src/test/java/seedu/address/model/person/AttendanceTest.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 
@@ -56,6 +57,24 @@ public class AttendanceTest {
         Attendance attendance = new Attendance(LocalDate.now(), true);
         attendance.setAttendance(false);
         assertFalse(attendance.isPresent());
+    }
+
+    /**
+     * Tests if two dates in the same week are correctly identified as being in the same week.
+     */
+    @Test
+    public void isSameWeek_sameWeek_true() {
+        Attendance attendance = new Attendance(LocalDate.of(2023, 10, 10), true);
+        assertTrue(attendance.isSameWeek(LocalDate.of(2023, 10, 12)));
+    }
+
+    /**
+     * Tests if two dates in different weeks are correctly identified as not being in the same week.
+     */
+    @Test
+    public void isSameWeek_differentWeek_false() {
+        Attendance attendance = new Attendance(LocalDate.of(2023, 10, 10), true);
+        assertFalse(attendance.isSameWeek(LocalDate.of(2023, 10, 17)));
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -56,24 +56,27 @@ public class PersonTest {
     }
 
     /**
+     * Tests if an empty Optional is returned when there's no attendance record for the current week.
+     */
+    @Test
+    public void getAttendanceForCurrentWeek_noAttendance_emptyOptional()  {
+        Person emptyAlice = new PersonBuilder(ALICE).build();
+        Optional<Attendance> result = emptyAlice.getAttendanceForCurrentWeek();
+        System.out.println(result);
+        assertFalse(result.isPresent());
+    }
+
+    /**
      * Tests if an attendance record for the current week is correctly retrieved when it exists.
      */
     @Test
     public void getAttendanceForCurrentWeek_attendanceExists_optionalWithAttendance() {
         Attendance attendance = new Attendance(LocalDate.now(), true);
-        ALICE.addAttendance(attendance);
-        Optional<Attendance> result = ALICE.getAttendanceForCurrentWeek();
+        Person emptyAlice = new PersonBuilder(ALICE).build();
+        emptyAlice.addAttendance(attendance);
+        Optional<Attendance> result = emptyAlice.getAttendanceForCurrentWeek();
         assertTrue(result.isPresent());
         assertTrue(result.get().isSameWeek(LocalDate.now()));
-    }
-
-    /**
-     * Tests if an empty Optional is returned when there's no attendance record for the current week.
-     */
-    @Test
-    public void getAttendanceForCurrentWeek_noAttendance_emptyOptional()  {
-        Optional<Attendance> result = ALICE.getAttendanceForCurrentWeek();
-        assertFalse(result.isPresent());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -59,7 +59,7 @@ public class PersonTest {
      * Tests if an empty Optional is returned when there's no attendance record for the current week.
      */
     @Test
-    public void getAttendanceForCurrentWeek_noAttendance_emptyOptional()  {
+    public void getAttendanceForCurrentWeek_noAttendance_emptyOptional() {
         Person emptyAlice = new PersonBuilder(ALICE).build();
         Optional<Attendance> result = emptyAlice.getAttendanceForCurrentWeek();
         System.out.println(result);

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -12,6 +12,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
@@ -50,6 +53,27 @@ public class PersonTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSamePerson(editedBob));
+    }
+
+    /**
+     * Tests if an attendance record for the current week is correctly retrieved when it exists.
+     */
+    @Test
+    public void getAttendanceForCurrentWeek_attendanceExists_optionalWithAttendance() {
+        Attendance attendance = new Attendance(LocalDate.now(), true);
+        ALICE.addAttendance(attendance);
+        Optional<Attendance> result = ALICE.getAttendanceForCurrentWeek();
+        assertTrue(result.isPresent());
+        assertTrue(result.get().isSameWeek(LocalDate.now()));
+    }
+
+    /**
+     * Tests if an empty Optional is returned when there's no attendance record for the current week.
+     */
+    @Test
+    public void getAttendanceForCurrentWeek_noAttendance_emptyOptional()  {
+        Optional<Attendance> result = ALICE.getAttendanceForCurrentWeek();
+        assertFalse(result.isPresent());
     }
 
     @Test


### PR DESCRIPTION
Addresses #14, #79 

Changes:

- Feat : Updated `MarkAttendanceCommand` to include the case if attendance is marked in the same week, command simply updates `attendanceRecord`. If marking attendance is not done in same week, proceed to create new `Attendance` object and add into `attendanceRecord`.

- Feat: Updated `MarkAttendanceCommand` and `MarkAttendanceCommandParser` to allow multiple student name or student id to be taken as input and processed for faster attendance marking

- Tests: Updated all relevant test files to cover new modifications to classes

- Docs: Updated `UserGuide.md` to reflect all enhancements